### PR TITLE
delete useless gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,9 +37,6 @@ group :development, :test do
   gem 'binding_of_caller'
   gem 'better_errors'
 
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0', group: :development
-
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'capybara'


### PR DESCRIPTION
The web console gem is use for better error but it makes fail heroku deployment
